### PR TITLE
Update Quotation Tables for Versioning Support

### DIFF
--- a/components/quotation-history-table.tsx
+++ b/components/quotation-history-table.tsx
@@ -396,7 +396,7 @@ export function QuotationHistoryTable({
                     <div className="flex items-center justify-between">
                       <h4 className="font-semibold">Response #{response.responseNumber}</h4>
                       <div className="flex items-center gap-2">
-                        {getResponseStatusBadge(response.overallStatus)}
+                        {/* {getResponseStatusBadge(response.overallStatus)} */}
                         <span className="text-sm text-muted-foreground">
                           {new Date(response.responseDate).toLocaleDateString()}
                         </span>
@@ -447,8 +447,8 @@ export function QuotationHistoryTable({
                               <TableRow>
                                 <TableHead>SKU</TableHead>
                                 <TableHead>Description</TableHead>
-                                <TableHead>Original Qty</TableHead>
-                                <TableHead>Original Price</TableHead>
+                                <TableHead>v{responseVersion?.versionNumber} Qty</TableHead>
+                                <TableHead>v{responseVersion?.versionNumber} Price</TableHead>
                                 <TableHead>Response Status</TableHead>
                                 <TableHead>Requested Qty</TableHead>
                                 <TableHead>Requested Price</TableHead>

--- a/components/quotation-response-form.tsx
+++ b/components/quotation-response-form.tsx
@@ -84,6 +84,7 @@ export function QuotationResponseForm({
         </CardHeader>
         <CardContent>
           <ResponseItemsTable
+            versionNumber={quotationVersion.versionNumber}
             items={quotationVersion.items}
             itemResponses={itemResponses}
             setItemResponses={setItemResponses}

--- a/components/response-items-table.tsx
+++ b/components/response-items-table.tsx
@@ -14,6 +14,7 @@ import { useCurrency } from '@/contexts/currency-context';
 import type { ResponseItemStatus } from '@/lib/types/quotation-response';
 
 interface ResponseItemsTableProps {
+  versionNumber: number;
   items: any[];
   itemResponses: Record<number, {
     itemStatus: ResponseItemStatus;
@@ -25,6 +26,7 @@ interface ResponseItemsTableProps {
 }
 
 export function ResponseItemsTable({ 
+  versionNumber,
   items, 
   itemResponses, 
   setItemResponses 
@@ -47,8 +49,8 @@ export function ResponseItemsTable({
         <TableRow>
           <TableHead>SKU</TableHead>
           <TableHead>Description</TableHead>
-          <TableHead>Original Qty</TableHead>
-          <TableHead>Original Price</TableHead>
+          <TableHead>v{versionNumber} Qty</TableHead>
+          <TableHead>v{versionNumber} Price</TableHead>
           <TableHead>Status</TableHead>
           <TableHead>Requested Qty</TableHead>
           <TableHead>Requested Price</TableHead>


### PR DESCRIPTION
- Commented out the response status badge in the Quotation History Table for cleaner presentation.
- Updated table headers in both Quotation History Table and Response Items Table to reflect version-specific quantities and prices.
- Passed version number as a prop to the Response Items Table to ensure accurate display of versioned data.